### PR TITLE
Added staging and index buffers

### DIFF
--- a/Volcanic/HelloTriangleApplication.h
+++ b/Volcanic/HelloTriangleApplication.h
@@ -27,13 +27,17 @@ private:
 	VkRenderPass renderPass;
 	VkPipelineLayout pipelineLayout;
 	VkPipeline graphicsPipeline;
-	VkCommandPool commandPool;
+	VkCommandPool drawCommandPool;
+	VkCommandPool transferCommandPool;
 	VkSemaphore imageAvailableSemaphore;
 	VkSemaphore renderFinishedSemaphore;
 	size_t currentFrame = 0;
 	bool framebufferResized = false;
 	VkBuffer vertexBuffer;
 	VkDeviceMemory vertexBufferMemory;
+	VkBuffer indexBuffer;
+	VkDeviceMemory indexBufferMemory;
+
 
 	const int WIDTH = 800;
 	const int HEIGHT = 600;
@@ -90,9 +94,15 @@ private:
 	};
 
 	const std::vector<Vertex> vertices = {
-		{{0.0f, -0.5f}, {1.0f, 0.0f, 0.0f}},
-		{{0.5f, 0.5f}, {0.0f, 1.0f, 0.0f}},
-		{{-0.5f, 0.5f}, {0.0f, 0.0f, 1.0f}}
+		{{-0.5f, -0.5f}, {1.0f, 0.0f, 0.0f}},
+		{{0.5f, -0.5f}, {0.0f, 1.0f, 0.0f}},
+		{{0.5f, 0.5f}, {0.0f, 0.0f, 1.0f}},
+		{{-0.5f, 0.5f}, {1.0f, 1.0f, 1.0f}}
+	};
+
+
+	const std::vector<uint16_t> indices = {
+		0, 1, 2, 2, 3, 0
 	};
 
 public:
@@ -159,6 +169,12 @@ private:
 	void recreateSwapChain();
 
 	void createVertexBuffer();
+
+	void createBuffer(VkDeviceSize size, VkBufferUsageFlags usage, VkMemoryPropertyFlags properties, VkBuffer& buffer, VkDeviceMemory& bufferMemory);
+
+	void copyBuffer(VkBuffer srcBuffer, VkBuffer dstBuffer, VkDeviceSize size);
+
+	void createIndexBuffer();
 
 	uint32_t findMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties);
 


### PR DESCRIPTION
Vertex buffer now using optimal local device memory type.

Added separate staging buffer for optimal data transfer to GPU vertex buffer.
Added separate command pool for data transfer.
Added copyBuffer() member function for transferring data between buffers.
Added Indices data.
Added index buffer for optimal usage of vertices.


Updated buffer creation member function to allow for reusable code.
Updated createCommandBuffers() to allow for indexing.
Updated cleanup() to destroy/free resources once finished with. 